### PR TITLE
Upgrade to LTS-12

### DIFF
--- a/aeson-injector.cabal
+++ b/aeson-injector.cabal
@@ -31,8 +31,8 @@ library
       Data.Aeson.WithField
 
   build-depends:
-      base                 >= 4.7     && < 4.11
-    , aeson                >= 0.11    && < 1.3
+      base                 >= 4.7     && < 4.12
+    , aeson                >= 0.11    && < 1.5
     , bifunctors           >= 5.2     && < 6
     , deepseq              >= 1.4     && < 2
     , hashable             >= 1.0     && < 2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,10 +3,6 @@ resolver: lts-12.7
 packages:
 - '.'
 
-extra-deps:
-- swagger2-2.3
-
-
 # system-ghc: true
 # nix:
 #   enable: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,11 @@
-resolver: lts-9.6
-#resolver: nightly-2017-10-04
+resolver: lts-12.7
 
 packages:
 - '.'
-extra-deps: []
+
+extra-deps:
+- swagger2-2.3
+
 
 # system-ghc: true
 # nix:


### PR DESCRIPTION
- Pushing constraints to allow build `aeson-injector` with LTS-12 and newer `base` and `aeson`