### PR TITLE
bump the upper version bound of base for ghc-8.6

### DIFF
--- a/aeson-injector.cabal
+++ b/aeson-injector.cabal
@@ -32,7 +32,7 @@ library
       Data.Aeson.WithField
 
   build-depends:
-      base                 >= 4.7     && < 4.12
+      base                 >= 4.7     && < 4.13
     , aeson                >= 0.11    && < 1.5
     , bifunctors           >= 5.2     && < 6
     , deepseq              >= 1.4     && < 2


### PR DESCRIPTION
We can perhaps make the upper bound `<5`.