### PR TITLE
Return the first error in json decode

### DIFF
--- a/aeson-injector.cabal
+++ b/aeson-injector.cabal
@@ -14,6 +14,7 @@ tested-with:
     GHC == 8.4.3
   , GHC == 8.6.5
   , GHC == 8.8.1
+  , GHC == 8.10.7
 extra-source-files:
   README.md
   CHANGELOG.md
@@ -30,15 +31,15 @@ library
       Data.Aeson.WithField
 
   build-depends:
-      base                 >= 4.7     && < 4.14
+      base                 >= 4.7     && < 4.17
     , aeson                >= 0.11    && < 1.6
     , bifunctors           >= 5.2     && < 6
     , deepseq              >= 1.4     && < 2
     , hashable             >= 1.0     && < 2.0
-    , lens                 >= 4.13    && < 5
-    , servant-docs         >= 0.7     && < 0.12
+    , lens                 >= 4.13    && < 5.2
+    , servant-docs         >= 0.7     && < 0.13
     , swagger2             >= 2.4     && < 3.0
-    , text                 >= 1.2     && < 2.0
+    , text                 >= 1.2     && < 2.1
     , unordered-containers >= 0.2.7   && < 0.3
 
 test-suite test-aeson-injector

--- a/aeson-injector.cabal
+++ b/aeson-injector.cabal
@@ -29,10 +29,12 @@ library
   exposed-modules:
       Data.Aeson.Unit
       Data.Aeson.WithField
+      Data.Aeson.WithField.Internal
 
   build-depends:
       base                 >= 4.7     && < 4.17
     , aeson                >= 0.11    && < 1.6
+    , attoparsec           >= 0.14    && < 0.15
     , bifunctors           >= 5.2     && < 6
     , deepseq              >= 1.4     && < 2
     , hashable             >= 1.0     && < 2.0

--- a/src/Data/Aeson/WithField/Internal.hs
+++ b/src/Data/Aeson/WithField/Internal.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Data.Aeson.WithField.Internal
+  ( mplus0
+  ) where
+
+import Data.Aeson.Types (Parser, JSONPath)
+
+import Unsafe.Coerce
+
+newtype P a = P 
+   { runP :: forall f r.
+                   JSONPath
+                -> Failure f r
+                -> Success a f r
+                -> f r }
+
+type Failure f r   = JSONPath -> String -> f r
+type Success a f r = a -> f r
+
+mplus0 :: forall a . Parser a -> Parser a -> Parser a
+mplus0 a b = unsafeCoerce @(P a) $ P $ \path kf ks -> 
+  let kf' p l = runP (unsafeCoerce b) path (\_ _ -> kf p l) ks
+  in runP (unsafeCoerce a) path kf' ks


### PR DESCRIPTION
It appeared that because we are adding a value field parser
we drop information about the actual error. Here we introduce
a new implementation of mplus (and thus Alternative) that will
return the first failure.

Unfortunately Parser internals are not exposed, so we had to
introduce a hack to overcome that. After the library will switch
to aeson-2 support and aeson will export Parser the hack can be
removed.

Before the patch:

> eitherDecode @(WithField "id" Int (OnlyField "foo" String)) "{\"id\":1,\"foo\":2}"
> Left "Error in $: key \"value\" not found"

After the patch:

> eitherDecode @(WithField "id" Int (OnlyField "foo" String)) "{\"id\":1,\"foo\":2}"
> Left "Error in $.foo: expected String, but encountered Number"

Fixes https://github.com/NCrashed/aeson-injector/issues/3